### PR TITLE
Add support for formatting the values in histogram

### DIFF
--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -104,7 +104,8 @@ class Aggregate
   #end
 
   #Generate a pretty-printed ASCII representation of the histogram
-  def to_s(columns=nil)
+  def to_s(columns=nil, value_formatter=nil)
+    value_formatter ||= :to_s.to_proc
 
     #default to an 80 column terminal, don't support < 80 for now
     if nil == columns
@@ -120,7 +121,7 @@ class Aggregate
     @buckets.each_with_index do |count, idx|
       next if 0 == count
       max_count = [max_count, count].max
-      disp_buckets << [idx, to_bucket(idx), count]
+      disp_buckets << [idx, value_formatter.call(to_bucket(idx)), count]
       total += count
     end
 
@@ -159,7 +160,7 @@ class Aggregate
       prev_index = x[0]
 
       #Add the value
-      row = sprintf("%#{value_width}d |", x[1])
+      row = sprintf("%#{value_width}s |", x[1])
 
       #Add the bar
       bar_size = (x[2]/weight).to_i

--- a/test/ts_aggregate.rb
+++ b/test/ts_aggregate.rb
@@ -93,6 +93,14 @@ class SimpleStatsTest < MiniTest::Test
     puts @stats.to_s
   end
 
+  def test_histogram_times_2
+    puts @stats.to_s(80, method(:times_2))
+  end
+
+  def times_2(value)
+    value * 2
+  end
+
   def test_outlier
     assert_equal 0, @stats.outliers_low
     assert_equal 0, @stats.outliers_high


### PR DESCRIPTION
This allows for storing scalar values in the `Aggregate`, but formatting the values in a more domain-specific fashion. 

An example of this is using a linear histogram with unix timestamps as the values. 
It is more useful to output the histogram using a formatted time instead of the unix epoch delta value. 

/cc @josephruscio 
