### PR TITLE
Simply use require

### DIFF
--- a/test/ts_aggregate.rb
+++ b/test/ts_aggregate.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
-require File.expand_path('../../lib/aggregate', __FILE__)
+require 'aggregate'
 
 class SimpleStatsTest < MiniTest::Test
 


### PR DESCRIPTION
Hi,

This PR fixes the method of requiring aggregate by changing `File.expand_path` method to simply using `require`.

This comes handy for downstream (at least, in maintaining the Debian package of this library), where the tests fail when built in a clean environment (schroot).

Hope this could be integrated here, as well :)

CC: @josephruscio @halorgium 