### PR TITLE
Use Dir.glob instead of git ls-files

### DIFF
--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "LICENSE",
      "README.textile"
   ]
-  s.files = `git ls-files -z`.split("\x0")
+  s.files = Dir.glob("**/*")
   s.homepage = %q{http://github.com/josephruscio/aggregate}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
     "LICENSE",
      "README.textile"
   ]
-  s.files = Dir.glob("**/*")
+  s.files = Dir["{lib}/**/*.*", "LICENSE", "README.textile"]
   s.homepage = %q{http://github.com/josephruscio/aggregate}
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
@@ -33,4 +33,3 @@ Gem::Specification.new do |s|
   else
   end
 end
-


### PR DESCRIPTION
Hi,

This drops the unnecessary dependency of `git`.
I've been maintaining this in Debian and while building this, adding `git` as a dependency is useless if we can do the same thing with `Dir.glob` :rocket: 