### PR TITLE
Travis-ci: added ppc64le support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: ruby
 rvm:
   - 1.9.3
@@ -5,3 +8,11 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+matrix:
+ exclude:
+    - rvm: 1.9.3
+      arch: ppc64le
+    - rvm: 2.3
+      arch: ppc64le
+    - rvm: 2.5
+      arch: ppc64le


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/aggregate/builds/205836383 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!