### PR TITLE
Modernize some code to fix warnings

### DIFF
--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -26,7 +26,7 @@ class Aggregate
   # Create a new Aggregate that maintains a binary logarithmic histogram
   # by default. Specifying values for low, high, and width configures
   # the aggregate to maintain a linear histogram with (high - low)/width buckets
-  def initialize (low=nil, high=nil, width=nil)
+  def initialize(low=nil, high=nil, width=nil)
     @count = 0
     @sum = 0.0
     @sum2 = 0.0
@@ -204,7 +204,7 @@ class Aggregate
     nil != @width
   end
 
-  def outlier? (data)
+  def outlier?(data)
 
     if data < @low
       @outliers_low += 1
@@ -231,7 +231,7 @@ class Aggregate
     end
   end
 
-  def right_bucket? index, data
+  def right_bucket?(index, data)
 
     # check invariant
     raise unless linear?
@@ -262,7 +262,7 @@ class Aggregate
   # A data point is added to the bucket[n] where the data point
   # is less than the value represented by bucket[n], but greater
   # than the value represented by bucket[n+1]
-  def to_index (data)
+  def to_index(data)
 
     # basic case is simple
     return log2(data).to_i if !linear?

--- a/test/ts_aggregate.rb
+++ b/test/ts_aggregate.rb
@@ -38,7 +38,7 @@ class SimpleStatsTest < MiniTest::Test
     i = 0
     @stats.each do |bucket, count|
       assert_equal 2**i, bucket
-      
+
       total_bucket_sum += count
       i += 1
     end
@@ -129,16 +129,16 @@ class LinearHistogramTest < MiniTest::Test
   def test_validation
 
     # Range cannot be 0
-    assert_raises(ArgumentError) {bad_stats = Aggregate.new(32,32,4)}
+    assert_raises(ArgumentError) { Aggregate.new(32,32,4) }
 
     # Range cannot be negative
-    assert_raises(ArgumentError) {bad_stats = Aggregate.new(32,16,4)}
+    assert_raises(ArgumentError) { Aggregate.new(32,16,4) }
 
     # Range cannot be < single bucket
-    assert_raises(ArgumentError) {bad_stats = Aggregate.new(16,32,17)}
+    assert_raises(ArgumentError) { Aggregate.new(16,32,17) }
 
     # Range % width must equal 0 (for now)
-    assert_raises(ArgumentError) {bad_stats = Aggregate.new(1,16384,1024)}
+    assert_raises(ArgumentError) { Aggregate.new(1,16384,1024) }
   end
 
   #XXX: Update test_bucket_contents() if you muck with @@DATA


### PR DESCRIPTION
* All method definitions use params
* Remove leading space before some method params
* Remove unused variable assignments in test suite