### PR TITLE
tests: drop usage of deprecated MiniTest namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "rake"
-gem "minitest"
+gem "minitest", "> 5.0.0"

--- a/test/ts_aggregate.rb
+++ b/test/ts_aggregate.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'aggregate'
 
-class SimpleStatsTest < MiniTest::Test
+class SimpleStatsTest < Minitest::Test
 
   def setup
     @stats = Aggregate.new
@@ -117,7 +117,7 @@ class SimpleStatsTest < MiniTest::Test
   end
 end
 
-class LinearHistogramTest < MiniTest::Test
+class LinearHistogramTest < Minitest::Test
   def setup
     @stats = Aggregate.new(0, 32768, 1024)
 


### PR DESCRIPTION
The MiniTest namespace was renamed to Minitest in Minitest 5.0, but a compatibility alias was kept. This alias has been dropped in Minitest 5.20, and the tests no longer work with that version.